### PR TITLE
Fix Redis TTL units

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -21,8 +21,8 @@ export class AppService {
 
     // Se não estiver no cache, gera novo dado (dados limpos sem informação de visita)
     const cleanData = `Dados do banco de dados - obtidos em ${new Date().toLocaleString()}`;
-    // Salva apenas os dados limpos no cache por 1 hora
-    await this.cacheManager.set(key, cleanData, 3600000);
+    // Salva apenas os dados limpos no cache por 1 hora (TTL em segundos)
+    await this.cacheManager.set(key, cleanData, 3600);
     console.log(`Dados obtidos do banco de dados - Visita #${this.counter}`);
     return `${cleanData} (Visita #${this.counter} - do banco de dados)`;
   }


### PR DESCRIPTION
## Summary
- fix TTL unit to seconds when caching data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684dfdf0d7b0832ea6864bb9d874b76a